### PR TITLE
Add node exporter port 9100 to Prometheus config.

### DIFF
--- a/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
+++ b/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
@@ -10,7 +10,7 @@ write_files:
       scrape_configs:
         - job_name: 'prometheus'
           static_configs:
-          - targets: ['localhost:9090']
+          - targets: ['localhost:9090','localhost:9100']
 
         - job_name: concourse
           scrape_interval: 15s


### PR DESCRIPTION
Adds the local node exporter port to the prometheus config.
This is related to https://github.com/companieshouse/prometheus-ami/pull/5
Resolves: DVOP-1628