### PR TITLE
Feature/GitHub recording rule

### DIFF
--- a/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
+++ b/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
@@ -1,4 +1,16 @@
 write_files:
+
+  - path: /etc/prometheus/github_rules.yml
+    owner: prometheus:prometheus
+    permissions: 0644
+    content: |
+      groups:
+        - name: github_rules
+          interval: 1m
+          rules:
+            - record: github_rate_used
+              expr: github_rate_limit - github_rate_remaining
+
   - path: /etc/prometheus/prometheus.yml
     owner: prometheus:prometheus
     permissions: 0644
@@ -6,6 +18,9 @@ write_files:
       global:
         scrape_interval:     30s
         evaluation_interval: 30s
+
+      rule_files:
+        - /etc/prometheus/github_rules.yml
 
       scrape_configs:
         - job_name: 'prometheus'

--- a/groups/prometheus/module-prometheus/security-groups.tf
+++ b/groups/prometheus/module-prometheus/security-groups.tf
@@ -35,14 +35,6 @@ resource "aws_security_group" "prometheus_server" {
     description = "Prometheus API"
   }
 
-  ingress {
-    from_port   = 9171
-    to_port     = 9171
-    protocol    = "tcp"
-    cidr_blocks = var.prometheus_cidrs
-    description = "Github Exporter"
-  }
-
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
Makes the following changes:
- Add a new Prometheus recording rule called 'github_rate_used'
- Add recording rule file path to main Prometheus config file.
- Also removed a security group rule relating to Github metrics which is not required.

Resolves: DVOP-1624