### PR TITLE
Remove remote state and update code

### DIFF
--- a/groups/prometheus/data.tf
+++ b/groups/prometheus/data.tf
@@ -8,7 +8,7 @@ data "vault_generic_secret" "internal_cidrs" {
 
 data "aws_vpc" "vpc" {
   tags = {
-    Name = var.vpc_name
+    Name = local.placement_vpc_pattern
   }
 }
 
@@ -20,7 +20,7 @@ data "aws_subnets" "subnets" {
 
   filter {
     name   = "tag:Name"
-    values = [var.subnet_pattern]
+    values = [local.placement_subnet_pattern]
   }
 }
 
@@ -30,5 +30,5 @@ data "aws_subnet" "subnet_data" {
 }
 
 data "aws_route53_zone" "dns_zone" {
-  name = var.dns_zone_name
+  name = local.dns_zone_name
 }

--- a/groups/prometheus/data.tf
+++ b/groups/prometheus/data.tf
@@ -1,0 +1,34 @@
+data "vault_generic_secret" "secrets" {
+  path = "applications/${var.aws_profile}/${var.environment}/${var.service}"
+}
+
+data "vault_generic_secret" "internal_cidrs" {
+  path = "aws-accounts/network/internal_cidr_ranges"
+}
+
+data "aws_vpc" "vpc" {
+  tags = {
+    Name = var.vpc_name
+  }
+}
+
+data "aws_subnets" "subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.vpc.id]
+  }
+
+  filter {
+    name   = "tag:Name"
+    values = [var.subnet_pattern]
+  }
+}
+
+data "aws_subnet" "subnet_data" {
+  for_each = toset(data.aws_subnets.subnets.ids)
+  id       = each.value
+}
+
+data "aws_route53_zone" "dns_zone" {
+  name = var.dns_zone_name
+}

--- a/groups/prometheus/locals.tf
+++ b/groups/prometheus/locals.tf
@@ -1,0 +1,16 @@
+locals {
+
+  internal_cidrs            = values(data.vault_generic_secret.internal_cidrs.data)
+  vpc_id                    = data.aws_vpc.vpc.id
+
+  subnets_map               = {
+    for s in data.aws_subnet.subnet_data: "${s.tags.Name}" => {
+        subnet_id   = s.id,
+        subnet_cidr = s.cidr_block
+    }
+  }
+
+  mgmt_private_subnet_ids   = [ for name, data in local.subnets_map: data.subnet_id ]
+  mgmt_private_subnet_cidrs = [ for name, data in local.subnets_map: data.subnet_cidr ]
+
+}

--- a/groups/prometheus/locals.tf
+++ b/groups/prometheus/locals.tf
@@ -13,4 +13,10 @@ locals {
   mgmt_private_subnet_ids   = [ for name, data in local.subnets_map: data.subnet_id ]
   mgmt_private_subnet_cidrs = [ for name, data in local.subnets_map: data.subnet_cidr ]
 
+  secrets                   = data.vault_generic_secret.secrets.data
+  dns_zone_name             = local.secrets.dns_zone_name
+  github_exporter_token     = local.secrets.github_exporter_token
+  placement_subnet_pattern  = local.secrets.placement_subnet_pattern
+  placement_vpc_pattern     = local.secrets.placement_vpc_pattern
+
 }

--- a/groups/prometheus/main.tf
+++ b/groups/prometheus/main.tf
@@ -2,29 +2,18 @@ provider "aws" {
   region = var.region
 }
 
-provider "vault" {
-  auth_login {
-    path = "auth/userpass/login/${var.vault_username}"
-    parameters = {
-      password = var.vault_password
-    }
-  }
-}
-data "vault_generic_secret" "secrets" {
-  path = "applications/${var.aws_profile}/${var.environment}/${var.service}"
-}
-
 terraform {
   backend "s3" {}
 }
 
 module "prometheus" {
+  source                       = "./module-prometheus"
+
   ami_version_pattern          = var.ami_version_pattern
   application_subnets          = local.mgmt_private_subnet_ids
   environment                  = var.environment
   instance_count               = var.instance_count
   instance_type                = var.instance_type
-  private_key_path             = var.private_key_path
   prometheus_cidrs             = concat(local.mgmt_private_subnet_cidrs)
   github_exporter_port         = var.github_exporter_port
   github_exporter_token        = data.vault_generic_secret.secrets.data["github_exporter_token"]
@@ -34,36 +23,10 @@ module "prometheus" {
   tag_name_regex               = var.tag_name_regex
   region                       = var.region
   service                      = var.service
-  source                       = "./module-prometheus"
-  ssh_cidrs                    = concat(local.internal_cidrs, local.vpn_cidrs)
+  ssh_cidrs                    = local.internal_cidrs
   ssh_keyname                  = var.ssh_keyname
-  vpc_id                       = local.vpc_id
-  web_cidrs                    = concat(local.internal_cidrs, local.vpn_cidrs)
-  dns_zone_id                  = var.dns_zone_id
+  vpc_id                       = data.aws_vpc.vpc.id
+  web_cidrs                    = local.internal_cidrs
+  dns_zone_id                  = data.aws_route53_zone.dns_zone.zone_id
   dns_zone_name                = var.dns_zone_name
-}
-
-# ------------------------------------------------------------------------------
-# Locals
-# ------------------------------------------------------------------------------
-
-locals {
-  vpc_id                    = data.terraform_remote_state.management_vpc.outputs.management_vpc_id
-  mgmt_private_subnet_cidrs = values(data.terraform_remote_state.management_vpc.outputs.management_private_subnet_cidrs)
-  mgmt_private_subnet_ids   = values(data.terraform_remote_state.management_vpc.outputs.management_private_subnet_ids)
-  vpn_cidrs                 = values(data.terraform_remote_state.management_vpc.outputs.vpn_cidrs)
-  internal_cidrs            = concat(values(data.terraform_remote_state.management_vpc.outputs.internal_cidrs), [data.terraform_remote_state.management_vpc.outputs.dmz_subnet])
-}
-
-# ------------------------------------------------------------------------------
-# Remote State
-# ------------------------------------------------------------------------------
-
-data "terraform_remote_state" "management_vpc" {
-  backend = "s3"
-  config = {
-    bucket = "development-${var.region}.terraform-state.ch.gov.uk"
-    key    = "aws-common-infrastructure-terraform/common-${var.region}/networking.tfstate"
-    region = var.region
-  }
 }

--- a/groups/prometheus/main.tf
+++ b/groups/prometheus/main.tf
@@ -16,7 +16,7 @@ module "prometheus" {
   instance_type                = var.instance_type
   prometheus_cidrs             = concat(local.mgmt_private_subnet_cidrs)
   github_exporter_port         = var.github_exporter_port
-  github_exporter_token        = data.vault_generic_secret.secrets.data["github_exporter_token"]
+  github_exporter_token        = local.github_exporter_token
   github_exporter_docker_image = var.github_exporter_docker_image
   github_exporter_docker_tag   = var.github_exporter_docker_tag
   prometheus_metrics_port      = var.prometheus_metrics_port
@@ -28,5 +28,5 @@ module "prometheus" {
   vpc_id                       = data.aws_vpc.vpc.id
   web_cidrs                    = local.internal_cidrs
   dns_zone_id                  = data.aws_route53_zone.dns_zone.zone_id
-  dns_zone_name                = var.dns_zone_name
+  dns_zone_name                = local.dns_zone_name
 }

--- a/groups/prometheus/module-prometheus/variables.tf
+++ b/groups/prometheus/module-prometheus/variables.tf
@@ -53,11 +53,6 @@ variable "tag_name_regex" {
   description = "The tag name regex uses to discover EC2 instances"
 }
 
-variable "private_key_path" {
-  type = string
-  description = "The private key path to be used"
-}
-
 variable "prometheus_cidrs" {
   type = list(string)
   description = "The Prometheus CIDR to be used"

--- a/groups/prometheus/profiles/development-eu-west-1/platform/vars
+++ b/groups/prometheus/profiles/development-eu-west-1/platform/vars
@@ -2,5 +2,4 @@ aws_profile   = "development-eu-west-1"
 environment   = "platform"
 region        = "eu-west-1"
 
-dns_zone_name = "aws.chdev.org"
 instance_type = "t3.medium"

--- a/groups/prometheus/profiles/development-eu-west-1/platform/vars
+++ b/groups/prometheus/profiles/development-eu-west-1/platform/vars
@@ -1,2 +1,5 @@
-# EC2 Instances
-environment = "platform"
+aws_profile   = "development-eu-west-1"
+environment   = "platform"
+region        = "eu-west-1"
+
+dns_zone_name = "aws.chdev.org"

--- a/groups/prometheus/profiles/development-eu-west-1/sandbox/vars
+++ b/groups/prometheus/profiles/development-eu-west-1/sandbox/vars
@@ -1,5 +1,3 @@
 aws_profile   = "development-eu-west-1"
 environment   = "sandbox"
 region        = "eu-west-1"
-
-dns_zone_name = "aws.chdev.org"

--- a/groups/prometheus/profiles/development-eu-west-1/sandbox/vars
+++ b/groups/prometheus/profiles/development-eu-west-1/sandbox/vars
@@ -1,2 +1,5 @@
-# EC2 Instances
-environment = "sandbox"
+aws_profile   = "development-eu-west-1"
+environment   = "sandbox"
+region        = "eu-west-1"
+
+dns_zone_name = "aws.chdev.org"

--- a/groups/prometheus/profiles/development-eu-west-2/devops/vars
+++ b/groups/prometheus/profiles/development-eu-west-2/devops/vars
@@ -1,2 +1,6 @@
-# EC2 Instances
-environment = "devops"
+aws_profile   = "development-eu-west-2"
+environment   = "devops"
+region        = "eu-west-2"
+
+dns_zone_name = "aws.chdev.org"
+vpc_name      = "Management"

--- a/groups/prometheus/profiles/development-eu-west-2/devops/vars
+++ b/groups/prometheus/profiles/development-eu-west-2/devops/vars
@@ -1,6 +1,3 @@
 aws_profile   = "development-eu-west-2"
 environment   = "devops"
 region        = "eu-west-2"
-
-dns_zone_name = "aws.chdev.org"
-vpc_name      = "Management"

--- a/groups/prometheus/variables.tf
+++ b/groups/prometheus/variables.tf
@@ -76,29 +76,3 @@ variable "service" {
   default = "prometheus"
   description = "The service name to be used when creating AWS resources"
 }
-
-variable "vault_username" {
-  type        = string
-  description = "Username for connecting to Vault - usually supplied through TF_VARS"
-}
-variable "vault_password" {
-  type        = string
-  description = "Password for connecting to Vault - usually supplied through TF_VARS"
-}
-
-variable "dns_zone_name" {
-  type = string
-  description = "The zone name to be used"
-}
-
-variable "vpc_name" {
-  type        = string
-  description = "The name of the VPC to deploy in to"
-  default     = "management-vpc"
-}
-
-variable "subnet_pattern" {
-  type        = string
-  description = "Pattern to use when looking up subnet data"
-  default     = "dev-management-private-*"
-}

--- a/groups/prometheus/variables.tf
+++ b/groups/prometheus/variables.tf
@@ -26,11 +26,6 @@ variable "instance_type" {
   description = "The type of EC2 instance to be provisoned"
 }
 
-variable "private_key_path" {
-  type = string
-  description = "The private key path to be used"
-}
-
 variable "github_exporter_docker_image" {
   type = string
   default = "infinityworks/github-exporter"
@@ -91,12 +86,19 @@ variable "vault_password" {
   description = "Password for connecting to Vault - usually supplied through TF_VARS"
 }
 
-variable "dns_zone_id" {
-  type  = string
-  description = "The ID of the zone to be used"
-}
-
 variable "dns_zone_name" {
   type = string
   description = "The zone name to be used"
+}
+
+variable "vpc_name" {
+  type        = string
+  description = "The name of the VPC to deploy in to"
+  default     = "management-vpc"
+}
+
+variable "subnet_pattern" {
+  type        = string
+  description = "Pattern to use when looking up subnet data"
+  default     = "dev-management-private-*"
 }

--- a/groups/prometheus/vault-providers/approle
+++ b/groups/prometheus/vault-providers/approle
@@ -1,0 +1,20 @@
+variable "hashicorp_vault_role_id" {
+  description = "The role identifier used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+variable "hashicorp_vault_secret_id" {
+  description = "The secret identifier used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/approle/login"
+
+    parameters = {
+      role_id   = var.hashicorp_vault_role_id
+      secret_id = var.hashicorp_vault_secret_id
+    }
+  }
+}

--- a/groups/prometheus/vault-providers/token
+++ b/groups/prometheus/vault-providers/token
@@ -1,0 +1,5 @@
+provider "vault" {
+    # Credentials read from the environment variables:
+    #   ${VAULT_ADDR}
+    #   ${VAULT_TOKEN}
+}

--- a/groups/prometheus/vault-providers/userpass
+++ b/groups/prometheus/vault-providers/userpass
@@ -1,0 +1,19 @@
+variable "hashicorp_vault_username" {
+  description = "The username used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+variable "hashicorp_vault_password" {
+  description = "The password used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.hashicorp_vault_username}"
+
+    parameters = {
+      password = var.hashicorp_vault_password
+    }
+  }
+}

--- a/groups/prometheus/vault.tf
+++ b/groups/prometheus/vault.tf
@@ -1,0 +1,1 @@
+vault-providers/userpass


### PR DESCRIPTION
Split `data` and `locals` in to their own files
Removed references to remote Terraform states
Added data lookup for VPC id
Added data lookups for various subnet data
Added locals to format data in to a lexigraphically sorted map to match the data order expected
Added data lookup for Route53 zone id based on the name
Updated module inputs
Added `vault-providers` and appropriate symlink
Added supporting variables
Updated profile vars as appropriate

Partially Resolves: DVOP-2130