### PR TITLE
Resize platform Prometheus

### DIFF
--- a/groups/prometheus/profiles/development-eu-west-1/platform/vars
+++ b/groups/prometheus/profiles/development-eu-west-1/platform/vars
@@ -1,2 +1,3 @@
 # EC2 Instances
 environment = "platform"
+instance_type = "t3.medium"


### PR DESCRIPTION
Updated `platform` instance type to `t3.medium` for increased resources