### PR TITLE
Deploy to Shared Services

### DIFF
--- a/groups/prometheus/data.tf
+++ b/groups/prometheus/data.tf
@@ -30,5 +30,6 @@ data "aws_subnet" "subnet_data" {
 }
 
 data "aws_route53_zone" "dns_zone" {
-  name = local.dns_zone_name
+  name         = local.dns_zone_name
+  private_zone = local.dns_zone_private_zone
 }

--- a/groups/prometheus/locals.tf
+++ b/groups/prometheus/locals.tf
@@ -14,6 +14,8 @@ locals {
   mgmt_private_subnet_cidrs = [ for name, data in local.subnets_map: data.subnet_cidr ]
 
   secrets                   = data.vault_generic_secret.secrets.data
+  ami_owner                 = local.secrets.ami_owner
+  dns_zone_private_zone     = local.secrets.dns_zone_private_zone
   dns_zone_name             = local.secrets.dns_zone_name
   github_exporter_token     = local.secrets.github_exporter_token
   placement_subnet_pattern  = local.secrets.placement_subnet_pattern

--- a/groups/prometheus/main.tf
+++ b/groups/prometheus/main.tf
@@ -9,6 +9,7 @@ terraform {
 module "prometheus" {
   source                       = "./module-prometheus"
 
+  ami_owner                    = local.ami_owner
   ami_version_pattern          = var.ami_version_pattern
   application_subnets          = local.mgmt_private_subnet_ids
   environment                  = var.environment
@@ -29,4 +30,5 @@ module "prometheus" {
   web_cidrs                    = local.internal_cidrs
   dns_zone_id                  = data.aws_route53_zone.dns_zone.zone_id
   dns_zone_name                = local.dns_zone_name
+  ssl_certificate_name         = var.ssl_certificate_name
 }

--- a/groups/prometheus/module-prometheus/data.tf
+++ b/groups/prometheus/module-prometheus/data.tf
@@ -1,0 +1,7 @@
+data "aws_acm_certificate" "certificate" {
+  count = local.create_ssl_certificate ? 0 : 1
+
+  domain      = var.ssl_certificate_name
+  statuses    = ["ISSUED"]
+  most_recent = true
+}

--- a/groups/prometheus/module-prometheus/ec2.tf
+++ b/groups/prometheus/module-prometheus/ec2.tf
@@ -1,5 +1,5 @@
 data "aws_ami" "prometheus" {
-  owners      = ["self"]
+  owners      = [var.ami_owner]
   name_regex  = "^prometheus-ami-\\d.\\d.\\d"
   most_recent = true
   filter {

--- a/groups/prometheus/module-prometheus/elb.tf
+++ b/groups/prometheus/module-prometheus/elb.tf
@@ -37,21 +37,23 @@ resource "aws_lb_target_group_attachment" "prometheus_server_web" {
 }
 
 # Configuration for Certificate
-
 resource "aws_acm_certificate" "certificate" {
+  count = local.create_ssl_certificate ? 1 : 0
+
   domain_name               = "${var.service}.${var.environment}.${var.dns_zone_name}"
   subject_alternative_names = ["*.${var.service}.${var.environment}.${var.dns_zone_name}"]
   validation_method         = "DNS"
 }
 
 resource "aws_route53_record" "certificate_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.certificate.domain_validation_options : dvo.domain_name => {
+  for_each = local.create_ssl_certificate ? {
+    for dvo in aws_acm_certificate.certificate[0].domain_validation_options : dvo.domain_name => {
       name    = dvo.resource_record_name
       type    = dvo.resource_record_type
       record  = dvo.resource_record_value
     }
-  }
+  } : {}
+
   allow_overwrite = true
   name            = each.value.name
   records         = [each.value.record]
@@ -61,7 +63,9 @@ resource "aws_route53_record" "certificate_validation" {
 }
 
 resource "aws_acm_certificate_validation" "certificate" {
-  certificate_arn         = aws_acm_certificate.certificate.arn
+  count = local.create_ssl_certificate ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.certificate[0].arn
   validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
 }
 
@@ -71,7 +75,7 @@ resource "aws_lb_listener" "prometheus_server_listener_443" {
   load_balancer_arn  = aws_lb.prometheus_server.arn
   port               = "443"
   protocol           = "HTTPS"
-  certificate_arn    = aws_acm_certificate_validation.certificate.certificate_arn
+  certificate_arn    = local.ssl_certificate_arn
   ssl_policy         = "ELBSecurityPolicy-2016-08"
   default_action {
     type             = "forward"

--- a/groups/prometheus/module-prometheus/locals.tf
+++ b/groups/prometheus/module-prometheus/locals.tf
@@ -1,0 +1,5 @@
+locals {
+
+  create_ssl_certificate  = var.ssl_certificate_name == "" ? true : false
+  ssl_certificate_arn     = var.ssl_certificate_name == "" ? aws_acm_certificate_validation.certificate[0].certificate_arn : data.aws_acm_certificate.certificate[0].arn
+}

--- a/groups/prometheus/module-prometheus/variables.tf
+++ b/groups/prometheus/module-prometheus/variables.tf
@@ -1,3 +1,8 @@
+variable "ami_owner" {
+  type        = string
+  description = "The owner string to use when looking up the AMI"
+}
+
 variable "ami_version_pattern" {
   type = string
   description = "The AMI version pattern to be used"
@@ -6,6 +11,16 @@ variable "ami_version_pattern" {
 variable "application_subnets" {
   type = list(string)
   description = "The application subnets to be used"
+}
+
+variable "dns_zone_id" {
+  type = string
+  description = "The zone ID to be used"
+}
+
+variable "dns_zone_name" {
+  type = string
+  description = "The zone name to be used"
 }
 
 variable "environment" {
@@ -78,6 +93,11 @@ variable "ssh_keyname" {
   description = "The ssh key to be used"
 }
 
+variable "ssl_certificate_name" {
+  type        = string
+  description = "The name of an existing ACM certificate to use for the ELB SSL listener. Setting this disables certificate creation"
+}
+
 variable "vpc_id" {
   type = string
   description = "The ID of the VPC to be used"
@@ -86,14 +106,4 @@ variable "vpc_id" {
 variable "web_cidrs" {
   type = list(string)
   description = "The CIDRs to grant web access to"
-}
-
-variable "dns_zone_id" {
-  type = string
-  description = "The zone ID to be used"
-}
-
-variable "dns_zone_name" {
-  type = string
-  description = "The zone name to be used"
 }

--- a/groups/prometheus/profiles/shared-services-eu-west-2/admin/vars
+++ b/groups/prometheus/profiles/shared-services-eu-west-2/admin/vars
@@ -2,5 +2,5 @@ aws_profile   = "shared-services-eu-west-2"
 environment   = "admin"
 region        = "eu-west-2"
 
-instance_type        = "t3.medium"
+instance_type        = "t3.small"
 ssl_certificate_name = "*.companieshouse.gov.uk"

--- a/groups/prometheus/profiles/shared-services-eu-west-2/admin/vars
+++ b/groups/prometheus/profiles/shared-services-eu-west-2/admin/vars
@@ -1,0 +1,6 @@
+aws_profile   = "shared-services-eu-west-2"
+environment   = "admin"
+region        = "eu-west-2"
+
+instance_type        = "t3.medium"
+ssl_certificate_name = "*.companieshouse.gov.uk"

--- a/groups/prometheus/profiles/shared-services-eu-west-2/platform/vars
+++ b/groups/prometheus/profiles/shared-services-eu-west-2/platform/vars
@@ -1,0 +1,6 @@
+aws_profile   = "shared-services-eu-west-2"
+environment   = "platform"
+region        = "eu-west-2"
+
+instance_type        = "t3.medium"
+ssl_certificate_name = "*.companieshouse.gov.uk"

--- a/groups/prometheus/variables.tf
+++ b/groups/prometheus/variables.tf
@@ -76,3 +76,9 @@ variable "service" {
   default = "prometheus"
   description = "The service name to be used when creating AWS resources"
 }
+
+variable "ssl_certificate_name" {
+  type        = string
+  description = "The name of an existing ACM certificate to use for the ELB SSL listener. Setting this disables certificate creation"
+  default     = ""
+}


### PR DESCRIPTION
Updated AMI lookup to allow for a variable `owner`
Added conditional data lookup for an existing ACM certificate
Updated ACM resources to be conditional based on whether an existing certificate is being used or not

* By default, the existing behaviour is maintained and a self-validating ACM certificate is created.
* If a certificate name is provided, an ACM cert is not created and the existing certificate is looked-up

Added profile vars for `shared-services`:
* admin
* platform