### PR TITLE
Avoid having any sensitive cloudinit data

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is comprised of a terraform script which when run will create the n
 
 ## Prerequisites
 
-* [Terraform](https://www.terraform.io/); tested with version v0.12.09,
+* [Terraform](https://www.terraform.io/); tested with version v0.12.31,
 * [AWS Command Line Interface](https://aws.amazon.com/cli/) 1.16.155+
 
 ### AWS Credentials
@@ -25,7 +25,6 @@ Variable    | Description | Examples
 aws_region  | AWS region to create the infrastructure  | eu-west-2
 environment  | AWS environment in which to create the infrastructure  | development
 instance_count | How many instances you want | 1
-private_key_path | The path of your private ssh key | "~/.mysshkey"
 prometheus_metrics_port | The desired port | 9999
 ssh_keyname | The keyname of the ssh profile you want to use | my-environment
 tag_name_regex | Prometheus tag | my-instance-tag

--- a/groups/prometheus/main.tf
+++ b/groups/prometheus/main.tf
@@ -4,6 +4,9 @@ provider "aws" {
 
 terraform {
   backend "s3" {}
+  required_providers {
+    aws = ">= 3.55, < 4.0"
+  }
 }
 
 module "prometheus" {

--- a/groups/prometheus/module-prometheus/cloud-init.tf
+++ b/groups/prometheus/module-prometheus/cloud-init.tf
@@ -26,9 +26,10 @@ data "template_cloudinit_config" "config" {
   part {
     content_type  = "text/cloud-config"
     content       = templatefile("${path.module}/cloud-init/files/bootstrap-commands.yml", {
-      hostname    ="${var.environment}-${var.service}-instance${count.index+1}"
+      hostname                     = "${var.environment}-${var.service}-instance${count.index+1}"
+      region                       = var.region       
       github_exporter_port         = var.github_exporter_port
-      github_exporter_token        = var.github_exporter_token
+      github_exporter_token_path   = local.parameter_store_path
       github_exporter_docker_image = var.github_exporter_docker_image
       github_exporter_docker_tag   = var.github_exporter_docker_tag
     })

--- a/groups/prometheus/module-prometheus/cloud-init/files/bootstrap-commands.yml
+++ b/groups/prometheus/module-prometheus/cloud-init/files/bootstrap-commands.yml
@@ -1,5 +1,6 @@
 runcmd:
   - hostnamectl set-hostname ${hostname}
-  - sudo docker run -d --restart=always -p ${github_exporter_port}:${github_exporter_port} -e GITHUB_TOKEN="${github_exporter_token}" ${github_exporter_docker_image}:${github_exporter_docker_tag}
+  - /usr/bin/aws ssm get-parameter --with-decryption --region ${region} --output text --query Parameter.Value --name ${github_exporter_token_path} > /github_exporter_token
+  - sudo docker run -d --restart=always -p ${github_exporter_port}:${github_exporter_port} -e GITHUB_TOKEN="$(cat /github_exporter_token)" ${github_exporter_docker_image}:${github_exporter_docker_tag}
   - systemctl enable prometheus
   - systemctl start prometheus

--- a/groups/prometheus/module-prometheus/data.tf
+++ b/groups/prometheus/module-prometheus/data.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "aws_acm_certificate" "certificate" {
   count = local.create_ssl_certificate ? 0 : 1
 

--- a/groups/prometheus/module-prometheus/data.tf
+++ b/groups/prometheus/module-prometheus/data.tf
@@ -7,3 +7,11 @@ data "aws_acm_certificate" "certificate" {
   statuses    = ["ISSUED"]
   most_recent = true
 }
+
+data "vault_generic_secret" "security_kms_keys" {
+  path = "aws-accounts/security/kms"
+}
+
+data "vault_generic_secret" "security_s3_buckets" {
+  path = "aws-accounts/security/s3"
+}

--- a/groups/prometheus/module-prometheus/ec2.tf
+++ b/groups/prometheus/module-prometheus/ec2.tf
@@ -11,7 +11,7 @@ data "aws_ami" "prometheus" {
 resource "aws_instance" "prometheus_instance" {
   count                  = var.instance_count
   ami                    = data.aws_ami.prometheus.id
-  iam_instance_profile   = aws_iam_role.ec2_readonly.name
+  iam_instance_profile   = aws_iam_instance_profile.instance_profile.name
   instance_type          = var.instance_type
   subnet_id              = element(var.application_subnets,count.index)
   key_name               = var.ssh_keyname
@@ -19,13 +19,40 @@ resource "aws_instance" "prometheus_instance" {
   user_data_base64       = data.template_cloudinit_config.config.*.rendered[count.index]
 
   root_block_device {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type = "gp3"
+    volume_size = var.root_volume_size_gb
+    encrypted   = true
+    kms_key_id  = module.ebs_kms.key_arn
+  }
+
+  ebs_block_device {
+    device_name = "/dev/xvdb"
+    volume_type = "gp3"
+    volume_size = var.data_volume_size_gb
+    encrypted   = true
+    kms_key_id  = module.ebs_kms.key_arn
+    snapshot_id = tolist(data.aws_ami.prometheus.block_device_mappings)[1].ebs.snapshot_id
+  }
+
+  ebs_block_device {
+    device_name = "/dev/xvdc"
+    volume_type = "gp3"
+    volume_size = var.data_volume_size_gb
+    encrypted   = true
+    kms_key_id  = module.ebs_kms.key_arn
+    snapshot_id = tolist(data.aws_ami.prometheus.block_device_mappings)[2].ebs.snapshot_id
   }
 
   volume_tags = {
     Snapshot = "daily"
     Name     = "${var.environment}-${var.service}-instance${count.index+1}"
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    instance_metadata_tags      = "enabled"
+    http_put_response_hop_limit = 2
   }
 
   tags = {

--- a/groups/prometheus/module-prometheus/ec2.tf
+++ b/groups/prometheus/module-prometheus/ec2.tf
@@ -1,10 +1,10 @@
 data "aws_ami" "prometheus" {
   owners      = [var.ami_owner]
-  name_regex  = "^prometheus-ami-\\d.\\d.\\d"
+  name_regex  = "^prometheus-\\d.\\d.\\d"
   most_recent = true
   filter {
     name   = "name"
-    values = ["prometheus-ami-${var.ami_version_pattern}"]
+    values = ["prometheus-${var.ami_version_pattern}"]
   }
 }
 

--- a/groups/prometheus/module-prometheus/iam-role.tf
+++ b/groups/prometheus/module-prometheus/iam-role.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "parameter_store_read_policy" {
     effect  = "Allow"
 
     resources = [
-        "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${var.service}/${var.environment}/*"
+        "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter${local.parameter_store_path}"
     ]
   }
 

--- a/groups/prometheus/module-prometheus/iam-role.tf
+++ b/groups/prometheus/module-prometheus/iam-role.tf
@@ -1,4 +1,4 @@
-data "aws_iam_policy_document" "ec2_readonly" {
+data "aws_iam_policy_document" "instance_policy" {
   statement {
     actions = ["sts:AssumeRole"]
     principals {
@@ -9,19 +9,24 @@ data "aws_iam_policy_document" "ec2_readonly" {
   }
 }
 
-resource "aws_iam_role" "ec2_readonly" {
-  name = "${var.environment}-${var.service}-ec2-read-only"
-  assume_role_policy = data.aws_iam_policy_document.ec2_readonly.json
+resource "aws_iam_role" "instance_role" {
+  name = "${var.environment}-${var.service}-role"
+  assume_role_policy = data.aws_iam_policy_document.instance_policy.json
 }
 
-resource "aws_iam_role_policy_attachment" "ec2_readonly_attach" {
-  role       = aws_iam_role.ec2_readonly.name
+resource "aws_iam_role_policy_attachment" "managed_ec2_readonly_attach" {
+  role       = aws_iam_role.instance_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
 }
 
-resource "aws_iam_instance_profile" "ec2_readonly" {
-    name = "${var.environment}-${var.service}-ec2-read-only"
-    role = aws_iam_role.ec2_readonly.name
+resource "aws_iam_role_policy_attachment" "managed_ssm_service_attach" {
+  role       = aws_iam_role.instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "instance_profile" {
+    name = "${var.environment}-${var.service}-instance-profile"
+    role = aws_iam_role.instance_role.name
 }
 
 data "aws_iam_policy_document" "parameter_store_read_policy" {
@@ -36,7 +41,7 @@ data "aws_iam_policy_document" "parameter_store_read_policy" {
   }
 
   statement {
-    sid     = "AllowKMSDecrypt"
+    sid     = "AllowKMSDecryptForSSMKey"
     actions = ["kms:Decrypt"]
     effect  = "Allow"
 
@@ -45,6 +50,61 @@ data "aws_iam_policy_document" "parameter_store_read_policy" {
 }
 
 resource "aws_iam_role_policy" "parameter_store_read_policy" {
-  role   = aws_iam_role.ec2_readonly.name
+  role   = aws_iam_role.instance_role.name
   policy = data.aws_iam_policy_document.parameter_store_read_policy.json
+}
+
+data "aws_iam_policy_document" "ebs_encryption_policy" {
+  statement {
+    sid     = "AllowKMSActionstForEBSKey"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    effect  = "Allow"
+
+    resources = [module.ebs_kms.key_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "ebs_encryption_policy" {
+  role   = aws_iam_role.instance_role.name
+  policy = data.aws_iam_policy_document.ebs_encryption_policy.json
+}
+
+data "aws_iam_policy_document" "ssm_service_policy" {
+  statement {
+    sid       = "SSMKMSOperations"
+    effect    = "Allow"
+    resources = [local.security_ssm_kms_key_id]
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+  }
+
+  statement {
+    sid    = "SSMS3Operations"
+    effect = "Allow"
+    resources = [
+      "arn:aws:s3:::${local.security_ssm_bucket_name}",
+      "arn:aws:s3:::${local.security_ssm_bucket_name}/*"
+    ]
+    actions = [
+      "s3:GetEncryptionConfiguration",
+      "s3:PutObject",
+      "s3:PutObjectACL"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "ssm_service_policy" {
+  role   = aws_iam_role.instance_role.name
+  policy = data.aws_iam_policy_document.ssm_service_policy.json
 }

--- a/groups/prometheus/module-prometheus/iam-role.tf
+++ b/groups/prometheus/module-prometheus/iam-role.tf
@@ -23,3 +23,28 @@ resource "aws_iam_instance_profile" "ec2_readonly" {
     name = "${var.environment}-${var.service}-ec2-read-only"
     role = aws_iam_role.ec2_readonly.name
 }
+
+data "aws_iam_policy_document" "parameter_store_read_policy" {
+  statement {
+    sid     = "AllowReadOfParameterStore"
+    actions = ["ssm:GetParameter"]
+    effect  = "Allow"
+
+    resources = [
+        "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${var.service}/${var.environment}/*"
+    ]
+  }
+
+  statement {
+    sid     = "AllowKMSDecrypt"
+    actions = ["kms:Decrypt"]
+    effect  = "Allow"
+
+    resources = [module.ssm_kms.key_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "parameter_store_read_policy" {
+  role   = aws_iam_role.ec2_readonly.name
+  policy = data.aws_iam_policy_document.parameter_store_read_policy.json
+}

--- a/groups/prometheus/module-prometheus/locals.tf
+++ b/groups/prometheus/module-prometheus/locals.tf
@@ -1,5 +1,11 @@
 locals {
+  parameter_store_path   = "/${var.service}/${var.environment}/github_exporter_token"
+  create_ssl_certificate = var.ssl_certificate_name == "" ? true : false
+  ssl_certificate_arn    = var.ssl_certificate_name == "" ? aws_acm_certificate_validation.certificate[0].certificate_arn : data.aws_acm_certificate.certificate[0].arn
 
-  create_ssl_certificate  = var.ssl_certificate_name == "" ? true : false
-  ssl_certificate_arn     = var.ssl_certificate_name == "" ? aws_acm_certificate_validation.certificate[0].certificate_arn : data.aws_acm_certificate.certificate[0].arn
+  default_tags = {
+    Terraform   = "true"
+    Application = upper(var.service)
+    Environment = var.environment
+  }
 }

--- a/groups/prometheus/module-prometheus/locals.tf
+++ b/groups/prometheus/module-prometheus/locals.tf
@@ -1,5 +1,9 @@
 locals {
-  parameter_store_path   = "/${var.service}/${var.environment}/github_exporter_token"
+  parameter_store_path = "/${var.service}/${var.environment}/github_exporter_token"
+
+  security_ssm_kms_key_id  = data.vault_generic_secret.security_kms_keys.data["session-manager-kms-key-arn"]  
+  security_ssm_bucket_name = data.vault_generic_secret.security_s3_buckets.data["session-manager-bucket-name"]
+
   create_ssl_certificate = var.ssl_certificate_name == "" ? true : false
   ssl_certificate_arn    = var.ssl_certificate_name == "" ? aws_acm_certificate_validation.certificate[0].certificate_arn : data.aws_acm_certificate.certificate[0].arn
 

--- a/groups/prometheus/module-prometheus/main.tf
+++ b/groups/prometheus/module-prometheus/main.tf
@@ -7,3 +7,13 @@ module "ssm_kms" {
   is_enabled              = true
   tags                    = local.default_tags
 }
+
+module "ebs_kms" {
+  source                  = "git@github.com:companieshouse/terraform-modules//aws/kms?ref=tags/1.0.235"
+  kms_key_alias           = "${var.service}-${var.environment}/ebs"
+  description             = "${var.service}-${var.environment} ebs volume encryption"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  is_enabled              = true
+  tags                    = local.default_tags
+}

--- a/groups/prometheus/module-prometheus/main.tf
+++ b/groups/prometheus/module-prometheus/main.tf
@@ -1,0 +1,9 @@
+module "ssm_kms" {
+  source                  = "git@github.com:companieshouse/terraform-modules//aws/kms?ref=tags/1.0.235"
+  kms_key_alias           = "${var.service}/ssm"
+  description             = "${var.service} parameter store use"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  is_enabled              = true
+  tags                    = local.default_tags
+}

--- a/groups/prometheus/module-prometheus/main.tf
+++ b/groups/prometheus/module-prometheus/main.tf
@@ -1,7 +1,7 @@
 module "ssm_kms" {
   source                  = "git@github.com:companieshouse/terraform-modules//aws/kms?ref=tags/1.0.235"
-  kms_key_alias           = "${var.service}/ssm"
-  description             = "${var.service} parameter store use"
+  kms_key_alias           = "${var.service}-${var.environment}/ssm"
+  description             = "${var.service}-${var.environment} parameter store use"
   deletion_window_in_days = 30
   enable_key_rotation     = true
   is_enabled              = true

--- a/groups/prometheus/module-prometheus/parameter-store.tf
+++ b/groups/prometheus/module-prometheus/parameter-store.tf
@@ -1,0 +1,7 @@
+resource "aws_ssm_parameter" "github_exporter_token_parameter" {
+  name   = local.parameter_store_path
+  type   = "SecureString"
+  value  = var.github_exporter_token
+  key_id = module.ssm_kms.key_arn
+  tags   = local.default_tags
+}

--- a/groups/prometheus/module-prometheus/variables.tf
+++ b/groups/prometheus/module-prometheus/variables.tf
@@ -38,6 +38,18 @@ variable "instance_type" {
   description = "The type of EC2 instance to be provisoned"
 }
 
+variable "root_volume_size_gb" {
+  type        = number
+  default     = 20
+  description = "The EC2 instance root volume size in Gibibytes (GiB)"
+}
+
+variable "data_volume_size_gb" {
+  type        = number
+  default     = 20
+  description = "The EC2 instance data volume size in Gibibytes (GiB)"
+}
+
 variable "github_exporter_docker_image" {
   type = string
   description = "The name of the exporter container image."


### PR DESCRIPTION
Remove the github token from the instance metadata and instead write it to parameter store and read it from within the cloud init bootstrap script.

Also, now uses the AMIs named "prometheus-#.#.#" (which are Amazon Linux 2 based), instead of Centos that was used on the AMIs named "prometheus-ami-#.#.#"

Also enables EBS encryption, IMDSv2, and access via SSM.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2775